### PR TITLE
[HEAP-39804]: format price, using a number not a string

### DIFF
--- a/shopify/README.md
+++ b/shopify/README.md
@@ -4,7 +4,7 @@ The tracking checkouts script is used to populate the docs for shopify at https:
 
 Helpful shopify docs:
  - [customize order status](https://help.shopify.com/en/manual/orders/status-tracking/customize-order-status)
- - [The checkout object](https://shopify.dev/api/liquid/objects/checkout?shpxid=338ca0c2-FDFC-4D5E-7B41-F6D2FF7FF884)
+ - [The checkout object](https://shopify.dev/api/liquid/objects/checkout)
 
 ## Embed 
 

--- a/shopify/README.md
+++ b/shopify/README.md
@@ -1,3 +1,22 @@
 # Shopify
 
 The tracking checkouts script is used to populate the docs for shopify at https://developers.heap.io/docs/shopify
+
+Helpful shopify docs:
+ - [customize order status](https://help.shopify.com/en/manual/orders/status-tracking/customize-order-status)
+ - [The checkout object](https://shopify.dev/api/liquid/objects/checkout?shpxid=338ca0c2-FDFC-4D5E-7B41-F6D2FF7FF884)
+
+## Embed 
+
+The code can be embedded in our docs via a short script: 
+
+<iframe id="github-iframe" src=""></iframe>
+<script>
+    fetch('https://api.github.com/repos/heap/docs-embeds/main/shopify/tracking-checkouts.html')
+        .then(function(response) {
+            return response.json();
+        }).then(function(data) {
+            var iframe = document.getElementById('github-iframe');
+            iframe.src = 'data:text/html;base64,' + encodeURIComponent(data['content']);
+        });
+</script>

--- a/shopify/tracking-checkouts.html
+++ b/shopify/tracking-checkouts.html
@@ -17,12 +17,35 @@
     return result
   }
 
-  {% if first_time_accessed %}
+
+  const formattedCurrencies = [
+    'USD',
+    'CAD',
+    'GBP',
+    'EUR'
+  ]
+
+   const getMoney = (objKey, amount) => {
+     const withSubunitKey = `${objKey}_subunit`
+     const curr = '{{ currency }}';
+
+     if (!formattedCurrencies.includes(curr)) {
+       return {
+         [withSubunitKey] : amount
+       };
+     }
+
+     return {
+       [objKey]: amount / 100.00,
+       [withSubunitKey]: amount
+     };
+   }
+
     window.Shopify?.checkout?.line_items?.forEach((item) => {
       heap.track("Purchased line item", {
         ...flattenObject(item),
         "order_id": {{ order_id }},
-        "total_price": {{ total_price | money_without_currency }},
+        ...getMoney("total_price", {{ total_price }}),
         "order_number": "{{ order_number }}",
         "customer_id": window.Shopify?.checkout?.customer_id
       });
@@ -39,23 +62,22 @@
       "billing_address.province_code": window.Shopify?.checkout?.billing_address?.province_code,
       "currency": "{{currency}}",
       "customer_id": "{{ customer.id }}",
-      "discounts.amount": {{ discounts_amount | money_without_currency }},
+      ...getMoney("discounts.amount", {{ discounts_amount }}),
       "discount.code": window.Shopify?.checkout?.discount?.code,
       "payment_due": window.Shopify?.checkout?.payment_due,
       "billing_address.first_name": "{{ customer.first_name }}",
       "billing_address.last_name": "{{ customer.last_name }}",
-      "gift_cards_amount": {{ gift_cards_amount | money_without_currency }},
-      "line_items_subtotal_price": {{ line_items_subtotal_price | money_without_currency }},
+      ...getMoney("gift_cards_amount", {{ gift_cards_amount }}),
+      ...getMoney("line_items_subtotal_price", {{ line_items_subtotal_price }}),
       "order_name": "{{ order_name }}",
       "requires_shipping": {{ requires_shipping }},
-      "shipping_rate.price": {{ shipping_price | money_without_currency }},
+      ...getMoney("shipping_rate.price", {{ shipping_price }}),
       "subtotal_price": window.Shopify?.checkout?.subtotal_price,
-      "total_tax": {{ tax_price | money_without_currency }},
-      "total_price": {{ total_price | money_without_currency }},
+      ...getMoney("total_tax", {{ total_price }}),
+      ...getMoney("total_price", {{ total_price }}),
     };
 
     heap.track("Checkout", flattenObject(checkoutEventProperties));
     heap.addUserProperties({ "email": "{{ email }}", customer_id: window.Shopify.checkout?.customer_id });
 
-  {% endif %}
 </script>

--- a/shopify/tracking-checkouts.html
+++ b/shopify/tracking-checkouts.html
@@ -3,12 +3,12 @@
   heap.load(<ENV ID HERE>);
 
   const flattenObject = (data, prefix) => {
-    var result = {}
-    for (var key in data) {
-      var currentPrefix = key;
-      if(prefix) currentPrefix =  prefix + '.' + key;
+    let result = {}
+    for (const key in data) {
+      const currentPrefix = key;
+      if (prefix) currentPrefix =  prefix + '.' + key;
       if (typeof data[key] == 'object' && data[key] !== null) {
-        var flatten = flattenObject(data[key], currentPrefix)
+        const flatten = flattenObject(data[key], currentPrefix)
         result = { ...result, ...flatten }
       } else {
         result[currentPrefix] = data[key];
@@ -41,6 +41,7 @@
      };
    }
 
+  {% if first_time_accessed %}
     window.Shopify?.checkout?.line_items?.forEach((item) => {
       heap.track("Purchased line item", {
         ...flattenObject(item),
@@ -73,11 +74,11 @@
       "requires_shipping": {{ requires_shipping }},
       ...getMoney("shipping_rate.price", {{ shipping_price }}),
       "subtotal_price": window.Shopify?.checkout?.subtotal_price,
-      ...getMoney("total_tax", {{ total_price }}),
+      ...getMoney("total_tax", {{ tax_price }}),
       ...getMoney("total_price", {{ total_price }}),
     };
 
     heap.track("Checkout", flattenObject(checkoutEventProperties));
     heap.addUserProperties({ "email": "{{ email }}", customer_id: window.Shopify.checkout?.customer_id });
-
+  {% endif %}
 </script>


### PR DESCRIPTION
- Formatting prices with `| money_without_currency ` returns a string and the value will have a comma if it's over $1000, said comma will cause an error and the event will not be tracked. 
- We are now just using the base value which will return 1000 for $10. For backward compatibility, we're going to format some currencies and return the shopify value. Unsupported currencies will just get the `${price}_subunit` value which is not divided by the subunit. 